### PR TITLE
🛠 Make automatically recognize new versions

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -39,7 +39,7 @@ jobs:
           push: true
           tags: |
             martinussuherman/alpine-code-server:${{ steps.get_version.outputs.version }}-amd64
-            martinussuherman/alpine-code-server:${{ steps.get_version.outputs.version }}-latest
+            martinussuherman/alpine-code-server:latest
 
       - name: Build and push arm64v8 image
         uses: docker/build-push-action@v2

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -23,6 +23,13 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Get latest code-server version
+        id: get_version
+        run: |
+          VERSION=$(curl -sX GET https://api.github.com/repos/coder/code-server/releases/latest \
+            | awk '/tag_name/{print $4;exit}' FS='[""]' | sed 's|^v||')
+          echo "::set-output name=version::$VERSION"
+      
       - name: Build and push amd64 image
         uses: docker/build-push-action@v2
         with:
@@ -30,7 +37,9 @@ jobs:
           context: .
           platforms: linux/amd64
           push: true
-          tags: martinussuherman/alpine-code-server:3.12.0-alpine3.13-amd64, martinussuherman/alpine-code-server:3.12.0-alpine3.13, martinussuherman/alpine-code-server:latest
+          tags: |
+            martinussuherman/alpine-code-server:${{ steps.get_version.outputs.version }}-amd64
+            martinussuherman/alpine-code-server:${{ steps.get_version.outputs.version }}-latest
 
       - name: Build and push arm64v8 image
         uses: docker/build-push-action@v2
@@ -39,4 +48,4 @@ jobs:
           context: .
           platforms: linux/arm64
           push: true
-          tags: martinussuherman/alpine-code-server:3.12.0-alpine3.13-arm64v8
+          tags: martinussuherman/alpine-code-server:${{ steps.get_version.outputs.version }}-arm64v8

--- a/.github/workflows/snyk-docker-amd64.yml
+++ b/.github/workflows/snyk-docker-amd64.yml
@@ -32,6 +32,6 @@ jobs:
         args: --file=amd64/Dockerfile
 
     - name: Upload result to GitHub Code Scanning
-      uses: github/codeql-action/upload-sarif@v1
+      uses: github/codeql-action/upload-sarif@v2
       with:
         sarif_file: snyk.sarif

--- a/.github/workflows/snyk-docker-amd64.yml
+++ b/.github/workflows/snyk-docker-amd64.yml
@@ -32,6 +32,6 @@ jobs:
         args: --file=amd64/Dockerfile
 
     - name: Upload result to GitHub Code Scanning
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: snyk.sarif

--- a/amd64/Dockerfile
+++ b/amd64/Dockerfile
@@ -28,10 +28,10 @@ RUN \
    openssh-client
 
 RUN \ 
-   if [ -z ${VERSION+x} ]; then \
-      VERSION=$(curl -sX GET https://api.github.com/repos/coder/code-server/releases/latest \
-      | awk '/tag_name/{print $4;exit}' FS='[""]' | sed 's|^v||'); \
-   fi && \
+   export VERSION=$(curl -sX GET https://api.github.com/repos/coder/code-server/releases/latest | awk '/tag_name/{print $4;exit}' FS='[""]' | sed 's|^v||') && \
+   echo "******************" && \
+   echo "Version : $VERSION" && \
+   echo "******************" && \
    curl -fsSL -o code-server-${VERSION}-linux-amd64.tar.gz https://github.com/coder/code-server/releases/download/v${VERSION}/code-server-${VERSION}-linux-amd64.tar.gz && \
    tar x -zf code-server-${VERSION}-linux-amd64.tar.gz && \
    rm code-server-${VERSION}-linux-amd64.tar.gz && \

--- a/amd64/Dockerfile
+++ b/amd64/Dockerfile
@@ -12,7 +12,7 @@ ENV \
    # should user shell set to nologin? (yes/no) \
    ENOLOGIN=no \
    # container user home dir \
-   EHOME=/home/vscode \
+   EHOME=/home/vscode
 
 COPY code-server /usr/bin/
 RUN chmod +x /usr/bin/code-server

--- a/amd64/Dockerfile
+++ b/amd64/Dockerfile
@@ -14,7 +14,7 @@ ENV \
    # container user home dir \
    EHOME=/home/vscode \
 
-COPY code-server /usr/bin/code-server
+COPY code-server /usr/bin/
 RUN chmod +x /usr/bin/code-server
 
 # Install dependencies

--- a/amd64/Dockerfile
+++ b/amd64/Dockerfile
@@ -33,11 +33,9 @@ RUN \
    echo "Version : $VERSION" && \
    echo "******************" && \
    curl -fsSL -o code-server-${VERSION}-linux-amd64.tar.gz https://github.com/coder/code-server/releases/download/v${VERSION}/code-server-${VERSION}-linux-amd64.tar.gz && \
-   tar x -zf code-server-${VERSION}-linux-amd64.tar.gz && \
+   tar -zxf code-server-${VERSION}-linux-amd64.tar.gz && \
    rm code-server-${VERSION}-linux-amd64.tar.gz && \
-   rm code-server-${VERSION}-linux-amd64/lib/node && \
-   mv code-server-${VERSION}-linux-amd64 /usr/lib/code-server && \
-   sed -i 's/"$ROOT\/lib\/node"/node/g'  /usr/lib/code-server/bin/code-server
+   mv code-server-${VERSION}-linux-amd64 /usr/lib/code-server
 
 ENTRYPOINT ["entrypoint-su-exec", "code-server"]
 CMD ["--bind-addr 0.0.0.0:8080"]

--- a/amd64/Dockerfile
+++ b/amd64/Dockerfile
@@ -35,8 +35,6 @@ RUN \
    curl -fsSL -o code-server-${VERSION}-linux-amd64.tar.gz https://github.com/coder/code-server/releases/download/v${VERSION}/code-server-${VERSION}-linux-amd64.tar.gz && \
    tar x -zf code-server-${VERSION}-linux-amd64.tar.gz && \
    rm code-server-${VERSION}-linux-amd64.tar.gz && \
-   rm code-server-${VERSION}-linux-amd64/node && \
-   rm code-server-${VERSION}-linux-amd64/code-server && \
    rm code-server-${VERSION}-linux-amd64/lib/node && \
    mv code-server-${VERSION}-linux-amd64 /usr/lib/code-server && \
    sed -i 's/"$ROOT\/lib\/node"/node/g'  /usr/lib/code-server/bin/code-server

--- a/amd64/Dockerfile
+++ b/amd64/Dockerfile
@@ -32,7 +32,7 @@ RUN \
       VERSION=$(curl -sX GET https://api.github.com/repos/coder/code-server/releases/latest \
       | awk '/tag_name/{print $4;exit}' FS='[""]' | sed 's|^v||'); \
    fi && \
-   wget https://github.com/coder/code-server/releases/download/v${VERSION}/code-server-${VERSION}-linux-amd64.tar.gz && \
+   curl -fsSL -o code-server-${VERSION}-linux-amd64.tar.gz https://github.com/coder/code-server/releases/download/v${VERSION}/code-server-${VERSION}-linux-amd64.tar.gz && \
    tar x -zf code-server-${VERSION}-linux-amd64.tar.gz && \
    rm code-server-${VERSION}-linux-amd64.tar.gz && \
    rm code-server-${VERSION}-linux-amd64/node && \

--- a/amd64/Dockerfile
+++ b/amd64/Dockerfile
@@ -13,8 +13,6 @@ ENV \
    ENOLOGIN=no \
    # container user home dir \
    EHOME=/home/vscode \
-   # code-server version \
-   VERSION=3.12.0
 
 COPY code-server /usr/bin/
 RUN chmod +x /usr/bin/code-server
@@ -29,14 +27,18 @@ RUN \
    nodejs \
    openssh-client
 
-RUN \
-   wget https://github.com/cdr/code-server/releases/download/v$VERSION/code-server-$VERSION-linux-amd64.tar.gz && \
-   tar x -zf code-server-$VERSION-linux-amd64.tar.gz && \
-   rm code-server-$VERSION-linux-amd64.tar.gz && \
-   rm code-server-$VERSION-linux-amd64/node && \
-   rm code-server-$VERSION-linux-amd64/code-server && \
-   rm code-server-$VERSION-linux-amd64/lib/node && \
-   mv code-server-$VERSION-linux-amd64 /usr/lib/code-server && \
+RUN \ 
+   if [ -z ${VERSION+x} ]; then \
+      VERSION=$(curl -sX GET https://api.github.com/repos/coder/code-server/releases/latest \
+      | awk '/tag_name/{print $4;exit}' FS='[""]' | sed 's|^v||'); \
+   fi && \
+   wget https://github.com/coder/code-server/releases/download/v${VERSION}/code-server-${VERSION}-linux-amd64.tar.gz && \
+   tar x -zf code-server-${VERSION}-linux-amd64.tar.gz && \
+   rm code-server-${VERSION}-linux-amd64.tar.gz && \
+   rm code-server-${VERSION}-linux-amd64/node && \
+   rm code-server-${VERSION}-linux-amd64/code-server && \
+   rm code-server-${VERSION}-linux-amd64/lib/node && \
+   mv code-server-${VERSION}-linux-amd64 /usr/lib/code-server && \
    sed -i 's/"$ROOT\/lib\/node"/node/g'  /usr/lib/code-server/bin/code-server
 
 ENTRYPOINT ["entrypoint-su-exec", "code-server"]

--- a/amd64/Dockerfile
+++ b/amd64/Dockerfile
@@ -14,7 +14,7 @@ ENV \
    # container user home dir \
    EHOME=/home/vscode \
 
-COPY code-server /usr/bin/
+COPY code-server /usr/bin/code-server
 RUN chmod +x /usr/bin/code-server
 
 # Install dependencies

--- a/arm64v8/Dockerfile
+++ b/arm64v8/Dockerfile
@@ -28,10 +28,10 @@ RUN \
    openssh-client
 
 RUN \
-   if [ -z ${VERSION+x} ]; then \
-      VERSION=$(curl -sX GET https://api.github.com/repos/coder/code-server/releases/latest \
-      | awk '/tag_name/{print $4;exit}' FS='[""]' | sed 's|^v||'); \
-   fi && \
+   export VERSION=$(curl -sX GET https://api.github.com/repos/coder/code-server/releases/latest | awk '/tag_name/{print $4;exit}' FS='[""]' | sed 's|^v||') && \
+   echo "******************" && \
+   echo "Version : $VERSION" && \
+   echo "******************" && \
    curl -fsSL -o code-server-${VERSION}-linux-arm64.tar.gz https://github.com/coder/code-server/releases/download/v${VERSION}/code-server-${VERSION}-linux-arm64.tar.gz && \
    tar x -zf code-server-${VERSION}-linux-arm64.tar.gz && \
    rm code-server-${VERSION}-linux-arm64.tar.gz && \

--- a/arm64v8/Dockerfile
+++ b/arm64v8/Dockerfile
@@ -12,7 +12,7 @@ ENV \
    # should user shell set to nologin? (yes/no) \
    ENOLOGIN=no \
    # container user home dir \
-   EHOME=/home/vscode \
+   EHOME=/home/vscode
 
 COPY code-server /usr/bin/
 RUN chmod +x /usr/bin/code-server

--- a/arm64v8/Dockerfile
+++ b/arm64v8/Dockerfile
@@ -14,7 +14,7 @@ ENV \
    # container user home dir \
    EHOME=/home/vscode \
 
-COPY code-server /usr/bin/code-server
+COPY code-server /usr/bin/
 RUN chmod +x /usr/bin/code-server
 
 # Install dependencies

--- a/arm64v8/Dockerfile
+++ b/arm64v8/Dockerfile
@@ -35,8 +35,6 @@ RUN \
    curl -fsSL -o code-server-${VERSION}-linux-arm64.tar.gz https://github.com/coder/code-server/releases/download/v${VERSION}/code-server-${VERSION}-linux-arm64.tar.gz && \
    tar x -zf code-server-${VERSION}-linux-arm64.tar.gz && \
    rm code-server-${VERSION}-linux-arm64.tar.gz && \
-   rm code-server-${VERSION}-linux-arm64/node && \
-   rm code-server-${VERSION}-linux-arm64/code-server && \
    rm code-server-${VERSION}-linux-arm64/lib/node && \
    mv code-server-${VERSION}-linux-arm64 /usr/lib/code-server && \
    sed -i 's/"$ROOT\/lib\/node"/node/g'  /usr/lib/code-server/bin/code-server

--- a/arm64v8/Dockerfile
+++ b/arm64v8/Dockerfile
@@ -32,7 +32,7 @@ RUN \
       VERSION=$(curl -sX GET https://api.github.com/repos/coder/code-server/releases/latest \
       | awk '/tag_name/{print $4;exit}' FS='[""]' | sed 's|^v||'); \
    fi && \
-   wget https://github.com/coder/code-server/releases/download/v${VERSION}/code-server-${VERSION}-linux-arm64.tar.gz && \
+   curl -fsSL -o code-server-${VERSION}-linux-arm64.tar.gz https://github.com/coder/code-server/releases/download/v${VERSION}/code-server-${VERSION}-linux-arm64.tar.gz && \
    tar x -zf code-server-${VERSION}-linux-arm64.tar.gz && \
    rm code-server-${VERSION}-linux-arm64.tar.gz && \
    rm code-server-${VERSION}-linux-arm64/node && \

--- a/arm64v8/Dockerfile
+++ b/arm64v8/Dockerfile
@@ -33,11 +33,9 @@ RUN \
    echo "Version : $VERSION" && \
    echo "******************" && \
    curl -fsSL -o code-server-${VERSION}-linux-arm64.tar.gz https://github.com/coder/code-server/releases/download/v${VERSION}/code-server-${VERSION}-linux-arm64.tar.gz && \
-   tar x -zf code-server-${VERSION}-linux-arm64.tar.gz && \
+   tar -zxf code-server-${VERSION}-linux-arm64.tar.gz && \
    rm code-server-${VERSION}-linux-arm64.tar.gz && \
-   rm code-server-${VERSION}-linux-arm64/lib/node && \
-   mv code-server-${VERSION}-linux-arm64 /usr/lib/code-server && \
-   sed -i 's/"$ROOT\/lib\/node"/node/g'  /usr/lib/code-server/bin/code-server
+   mv code-server-${VERSION}-linux-arm64 /usr/lib/code-server
 
 ENTRYPOINT ["entrypoint-su-exec", "code-server"]
 CMD ["--bind-addr 0.0.0.0:8080"]

--- a/arm64v8/Dockerfile
+++ b/arm64v8/Dockerfile
@@ -13,8 +13,6 @@ ENV \
    ENOLOGIN=no \
    # container user home dir \
    EHOME=/home/vscode \
-   # code-server version \
-   VERSION=3.12.0
 
 COPY code-server /usr/bin/
 RUN chmod +x /usr/bin/code-server
@@ -30,13 +28,17 @@ RUN \
    openssh-client
 
 RUN \
-   wget https://github.com/cdr/code-server/releases/download/v$VERSION/code-server-$VERSION-linux-arm64.tar.gz && \
-   tar x -zf code-server-$VERSION-linux-arm64.tar.gz && \
-   rm code-server-$VERSION-linux-arm64.tar.gz && \
-   rm code-server-$VERSION-linux-arm64/node && \
-   rm code-server-$VERSION-linux-arm64/code-server && \
-   rm code-server-$VERSION-linux-arm64/lib/node && \
-   mv code-server-$VERSION-linux-arm64 /usr/lib/code-server && \
+   if [ -z ${VERSION+x} ]; then \
+      VERSION=$(curl -sX GET https://api.github.com/repos/coder/code-server/releases/latest \
+      | awk '/tag_name/{print $4;exit}' FS='[""]' | sed 's|^v||'); \
+   fi && \
+   wget https://github.com/coder/code-server/releases/download/v${VERSION}/code-server-${VERSION}-linux-arm64.tar.gz && \
+   tar x -zf code-server-${VERSION}-linux-arm64.tar.gz && \
+   rm code-server-${VERSION}-linux-arm64.tar.gz && \
+   rm code-server-${VERSION}-linux-arm64/node && \
+   rm code-server-${VERSION}-linux-arm64/code-server && \
+   rm code-server-${VERSION}-linux-arm64/lib/node && \
+   mv code-server-${VERSION}-linux-arm64 /usr/lib/code-server && \
    sed -i 's/"$ROOT\/lib\/node"/node/g'  /usr/lib/code-server/bin/code-server
 
 ENTRYPOINT ["entrypoint-su-exec", "code-server"]

--- a/arm64v8/Dockerfile
+++ b/arm64v8/Dockerfile
@@ -14,7 +14,7 @@ ENV \
    # container user home dir \
    EHOME=/home/vscode \
 
-COPY code-server /usr/bin/
+COPY code-server /usr/bin/code-server
 RUN chmod +x /usr/bin/code-server
 
 # Install dependencies


### PR DESCRIPTION
1. Changed git url 
    `https://github.com/cdr/code-server` -> `https://github.com/coder/code-server`
2. Added the process of checking the released latest version using Github API.
    So, It doesn't need to manually modify the version in the dockerfile.
```
      VERSION=$(curl -sX GET https://api.github.com/repos/coder/code-server/releases/latest \
```
```
wget https://github.com/coder/code-server/releases/download/v${VERSION}/code-server-${VERSION}-linux-amd64.tar.gz && \
tar x -zf code-server-${VERSION}-linux-amd64.tar.gz && \
```

Need to test, but i think it will work properly